### PR TITLE
Specify hash length

### DIFF
--- a/src/interfaces/Hashable.php
+++ b/src/interfaces/Hashable.php
@@ -11,7 +11,9 @@
 interface Hashable {
 
 	/**
-	 * Returns a hash based on the value of the object.
+	 * Returns a string hash based on the value of the object. The string must not exceed
+	 * 255 bytes (255 ASCII characters or less when it contains Unicode characters that
+	 * need to be UTF-8 encoded) to allow using indexes on all database systems.
 	 *
 	 * @since 0.1
 	 *


### PR DESCRIPTION
I think some kind of specification is needed at this point. It's quite impossible to build efficient database structures on top of such an underspecified hash function if it can be anything (including megabytes of text).

Usually hashes are integers (e.g. in Java) or specified to use a hash function with a fixed or maximum length (e.g. MD5 is 128 bit, SHA1 is 160 bit).

My suggestion is 255 characters. This seems to be the smallest common maximum prefix length for database indexes, as far as I'm aware of.
