### PR TITLE
Reworked all equals methods

### DIFF
--- a/src/DataValues/DataValueObject.php
+++ b/src/DataValues/DataValueObject.php
@@ -28,13 +28,18 @@ abstract class DataValueObject implements DataValue {
 	 *
 	 * @since 0.1
 	 *
-	 * @param mixed $value
+	 * @param mixed $target
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
-	public function equals( $value ) {
-		return $value === $this ||
-			( is_object( $value ) && get_class( $value ) == get_called_class() && serialize( $value ) === serialize( $this ) );
+	public function equals( $target ) {
+		if ( $this === $target ) {
+			return true;
+		}
+
+		return is_object( $target )
+			&& get_called_class() === get_class( $target )
+			&& serialize( $this ) === serialize( $target );
 	}
 
 	/**

--- a/src/DataValues/UnDeserializableValue.php
+++ b/src/DataValues/UnDeserializableValue.php
@@ -181,22 +181,19 @@ class UnDeserializableValue extends DataValueObject {
 	 *
 	 * @since 0.1
 	 *
-	 * @param mixed $value
+	 * @param mixed $target
 	 *
 	 * @return bool
 	 */
-	public function equals( $value ) {
-		if ( $value === $this ) {
+	public function equals( $target ) {
+		if ( $this === $target ) {
 			return true;
 		}
 
-		if ( !( $value instanceof self ) ) {
-			return false;
-		}
-
-		return $value->data === $this->data
-			&& $value->type === $this->type
-			&& $value->error === $this->error;
+		return $target instanceof self
+			&& $this->data === $target->data
+			&& $this->type === $target->type
+			&& $this->error === $target->error;
 	}
 
 }

--- a/src/DataValues/UnknownValue.php
+++ b/src/DataValues/UnknownValue.php
@@ -88,13 +88,17 @@ class UnknownValue extends DataValueObject {
 	 *
 	 * @since 0.1
 	 *
-	 * @param mixed $value
+	 * @param mixed $target
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
-	public function equals( $value ) {
-		return $value === $this ||
-			( is_object( $value ) && get_class( $value ) == get_called_class() && $value->getValue() === $this->getValue() );
+	public function equals( $target ) {
+		if ( $this === $target ) {
+			return true;
+		}
+
+		return $target instanceof self
+			&& $this->value === $target->value;
 	}
 
 	/**

--- a/src/interfaces/Comparable.php
+++ b/src/interfaces/Comparable.php
@@ -17,7 +17,7 @@ interface Comparable {
 	 *
 	 * @param mixed $target
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public function equals( $target );
 


### PR DESCRIPTION
In classes that don't have subclasses the `get_class` approach is not necessary. But it's crucial if an `equals` implementation should be reused in subclasses. Which is the case in the abstract `DataValueObject`.