### PR TITLE
Remove misleading return doc

### DIFF
--- a/src/DataValues/NumberValue.php
+++ b/src/DataValues/NumberValue.php
@@ -46,8 +46,6 @@ class NumberValue extends DataValueObject {
 	 * @see Serializable::unserialize
 	 *
 	 * @param string $value
-	 *
-	 * @return NumberValue
 	 */
 	public function unserialize( $value ) {
 		$this->__construct( unserialize( $value ) );

--- a/src/DataValues/StringValue.php
+++ b/src/DataValues/StringValue.php
@@ -47,8 +47,6 @@ class StringValue extends DataValueObject {
 	 * @since 0.1
 	 *
 	 * @param string $value
-	 *
-	 * @return StringValue
 	 */
 	public function unserialize( $value ) {
 		$this->__construct( $value );

--- a/src/DataValues/UnDeserializableValue.php
+++ b/src/DataValues/UnDeserializableValue.php
@@ -22,7 +22,7 @@ class UnDeserializableValue extends DataValueObject {
 	private $data;
 
 	/**
-	 * @var string
+	 * @var string|null
 	 */
 	private $type;
 
@@ -34,20 +34,19 @@ class UnDeserializableValue extends DataValueObject {
 	/**
 	 * @since 0.1
 	 *
-	 * @param string $type The originally intended type
 	 * @param mixed $data The raw data structure
+	 * @param string|null $type The originally intended type
 	 * @param string $error The error that occurred when processing the original data structure.
 	 *
 	 * @throws InvalidArgumentException
-	 * @internal param mixed $value
 	 */
 	public function __construct( $data, $type, $error ) {
-		if ( !is_null( $type ) && !is_string( $type ) ) {
-			throw new InvalidArgumentException( '$type must be string or null' );
-		}
-
 		if ( is_object( $data ) ) {
 			throw new InvalidArgumentException( '$data must not be an object' );
+		}
+
+		if ( !is_string( $type ) && !is_null( $type ) ) {
+			throw new InvalidArgumentException( '$type must be a string or null' );
 		}
 
 		if ( !is_string( $error ) ) {
@@ -79,8 +78,6 @@ class UnDeserializableValue extends DataValueObject {
 	 * @since 0.1
 	 *
 	 * @param string $value
-	 *
-	 * @return StringValue
 	 */
 	public function unserialize( $value ) {
 		list( $type, $data, $error ) = unserialize( $value );
@@ -113,9 +110,9 @@ class UnDeserializableValue extends DataValueObject {
 	 */
 	public function toArray() {
 		return array(
-			'value' => $this->getArrayValue(),
-			'type' => $this->getTargetType(),
-			'error' => $this->getReason(),
+			'value' => $this->data,
+			'type' => $this->type,
+			'error' => $this->error,
 		);
 	}
 
@@ -135,7 +132,7 @@ class UnDeserializableValue extends DataValueObject {
 	 *
 	 * @since 0.1
 	 *
-	 * @return string
+	 * @return string|null
 	 */
 	public function getTargetType() {
 		return $this->type;

--- a/src/DataValues/UnknownValue.php
+++ b/src/DataValues/UnknownValue.php
@@ -42,8 +42,6 @@ class UnknownValue extends DataValueObject {
 	 * @since 0.1
 	 *
 	 * @param string $value
-	 *
-	 * @return StringValue
 	 */
 	public function unserialize( $value ) {
 		$this->__construct( unserialize( $value ) );


### PR DESCRIPTION
* `unserlialize` doesn't `@return` anything.
* Added missing `null` to doc.
* Fixed parameter order in `UnDeserializableValue` constructor.
* Inlined not needed getter calls.