### PR TITLE
Correct type hint for DataValue::getCopy

### DIFF
--- a/src/DataValues/DataValue.php
+++ b/src/DataValues/DataValue.php
@@ -79,4 +79,11 @@ interface DataValue extends \Hashable, \Comparable, \Serializable, \Immutable, \
 	 */
 	public function toArray();
 
+	/**
+	 * @see Copyable::getCopy
+	 *
+	 * @return DataValue
+	 */
+	public function getCopy();
+
 }


### PR DESCRIPTION
This "overrides" the `Copyable` interface for the only reason to have the correct, specific type hint.