### PR TITLE
Updated composer.json to PSR-4 autoloader.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,8 +31,8 @@
 			"src/interfaces",
 			"tests/phpunit/DataValueTest.php"
 		],
-		"psr-0": {
-			"DataValues\\": "src/"
+		"psr-4": {
+			"DataValues\\": "src/DataValues/"
 		}
 	},
 	"extra": {


### PR DESCRIPTION
The PSR-0 format has been deprecated in favor of PSR-4. For details, see:

* http://www.php-fig.org/psr/psr-0/
* http://www.php-fig.org/psr/psr-4/
* https://github.com/php-fig/fig-standards/commit/61f2d259