### PR TITLE
Move DataValue classes from Common to DataValues

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Contributions where also made by [several other awesome people]
 
 ### 2.0.0 (dev)
 
+* Added `MonolingualTextValue` and `MultilingualTextValue` (moved from DataValues Common)
 * Dropped `Copyable` interface
 * Dropped deprecated constant `DataValues_VERSION`, use `DATAVALUES_VERSION` instead
 * Raised required PHP version from 5.3 to 5.5

--- a/src/DataValues/MonolingualTextValue.php
+++ b/src/DataValues/MonolingualTextValue.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace DataValues;
+
+/**
+ * Class representing a monolingual text value.
+ *
+ * @since 2.0
+ *
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class MonolingualTextValue extends DataValueObject {
+
+	/**
+	 * @var string
+	 */
+	private $languageCode;
+
+	/**
+	 * @var string
+	 */
+	private $text;
+
+	/**
+	 * @since 2.0
+	 *
+	 * @param string $languageCode
+	 * @param string $text
+	 *
+	 * @throws IllegalValueException
+	 */
+	public function __construct( $languageCode, $text ) {
+		if ( !is_string( $languageCode ) || $languageCode === '' ) {
+			throw new IllegalValueException( '$languageCode must be a non-empty string' );
+		}
+		if ( !is_string( $text ) ) {
+			throw new IllegalValueException( '$text must be a string' );
+		}
+
+		$this->languageCode = $languageCode;
+		$this->text = $text;
+	}
+
+	/**
+	 * @see Serializable::serialize
+	 *
+	 * @return string
+	 */
+	public function serialize() {
+		return serialize( array( $this->languageCode, $this->text ) );
+	}
+
+	/**
+	 * @see Serializable::unserialize
+	 *
+	 * @param string $value
+	 */
+	public function unserialize( $value ) {
+		list( $languageCode, $text ) = unserialize( $value );
+		$this->__construct( $languageCode, $text );
+	}
+
+	/**
+	 * @see DataValue::getType
+	 *
+	 * @return string
+	 */
+	public static function getType() {
+		return 'monolingualtext';
+	}
+
+	/**
+	 * @see DataValue::getSortKey
+	 *
+	 * @return string
+	 */
+	public function getSortKey() {
+		// TODO: we might want to re-think this key. Perhaps the language should simply be omitted.
+		return $this->languageCode . $this->text;
+	}
+
+	/**
+	 * @see DataValue::getValue
+	 *
+	 * @return self
+	 */
+	public function getValue() {
+		return $this;
+	}
+
+	/**
+	 * Returns the text.
+	 *
+	 * @since 2.0
+	 *
+	 * @return string
+	 */
+	public function getText() {
+		return $this->text;
+	}
+
+	/**
+	 * Returns the language code.
+	 *
+	 * @since 2.0
+	 *
+	 * @return string
+	 */
+	public function getLanguageCode() {
+		return $this->languageCode;
+	}
+
+	/**
+	 * @see DataValue::getArrayValue
+	 *
+	 * @return string[]
+	 */
+	public function getArrayValue() {
+		return array(
+			'text' => $this->text,
+			'language' => $this->languageCode,
+		);
+	}
+
+	/**
+	 * Constructs a new instance of the DataValue from the provided data.
+	 * This can round-trip with @see getArrayValue
+	 *
+	 * @since 2.0
+	 *
+	 * @param string[] $data
+	 *
+	 * @return self
+	 * @throws IllegalValueException
+	 */
+	public static function newFromArray( $data ) {
+		self::requireArrayFields( $data, array( 'language', 'text' ) );
+
+		return new static( $data['language'], $data['text'] );
+	}
+
+}

--- a/src/DataValues/MultilingualTextValue.php
+++ b/src/DataValues/MultilingualTextValue.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace DataValues;
+
+/**
+ * Class representing a multilingual text value.
+ *
+ * @since 2.0
+ *
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class MultilingualTextValue extends DataValueObject {
+
+	/**
+	 * Array with language codes pointing to their associated texts.
+	 *
+	 * @var MonolingualTextValue[]
+	 */
+	private $texts = array();
+
+	/**
+	 * @since 2.0
+	 *
+	 * @param MonolingualTextValue[] $monolingualValues
+	 *
+	 * @throws IllegalValueException
+	 */
+	public function __construct( array $monolingualValues ) {
+		foreach ( $monolingualValues as $monolingualValue ) {
+			if ( !( $monolingualValue instanceof MonolingualTextValue ) ) {
+				throw new IllegalValueException( 'Can only construct MultilingualTextValue from MonolingualTextValue objects' );
+			}
+
+			$languageCode = $monolingualValue->getLanguageCode();
+
+			if ( array_key_exists( $languageCode, $this->texts ) ) {
+				throw new IllegalValueException( 'Can only add a single MonolingualTextValue per language to a MultilingualTextValue' );
+			}
+
+			$this->texts[$languageCode] = $monolingualValue;
+		}
+	}
+
+	/**
+	 * @see Serializable::serialize
+	 *
+	 * @return string
+	 */
+	public function serialize() {
+		return serialize( $this->texts );
+	}
+
+	/**
+	 * @see Serializable::unserialize
+	 *
+	 * @param string $value
+	 */
+	public function unserialize( $value ) {
+		$this->__construct( unserialize( $value ) );
+	}
+
+	/**
+	 * @see DataValue::getType
+	 *
+	 * @return string
+	 */
+	public static function getType() {
+		return 'multilingualtext';
+	}
+
+	/**
+	 * @see DataValue::getSortKey
+	 *
+	 * @return string|float|int
+	 */
+	public function getSortKey() {
+		return empty( $this->texts ) ? '' : reset( $this->texts )->getSortKey();
+	}
+
+	/**
+	 * Returns the texts as an array of monolingual text values.
+	 *
+	 * @since 2.0
+	 *
+	 * @return MonolingualTextValue[]
+	 */
+	public function getTexts() {
+		return $this->texts;
+	}
+
+	/**
+	 * Returns the multilingual text value
+	 * @see DataValue::getValue
+	 *
+	 * @return self
+	 */
+	public function getValue() {
+		return $this;
+	}
+
+	/**
+	 * @see DataValue::getArrayValue
+	 *
+	 * @return mixed
+	 */
+	public function getArrayValue() {
+		$values = array();
+
+		/**
+		 * @var MonolingualTextValue $text
+		 */
+		foreach ( $this->texts as $text ) {
+			$values[] = $text->getArrayValue();
+		}
+
+		return $values;
+	}
+
+	/**
+	 * Constructs a new instance of the DataValue from the provided data.
+	 * This can round-trip with
+	 * @see   getArrayValue
+	 *
+	 * @since 2.0
+	 *
+	 * @param mixed $data
+	 *
+	 * @throws IllegalValueException if $data is not an array.
+	 * @return self
+	 */
+	public static function newFromArray( $data ) {
+		if ( !is_array( $data ) ) {
+			throw new IllegalValueException( "array expected" );
+		}
+
+		$values = array();
+
+		foreach ( $data as $monolingualValue ) {
+			$values[] = MonolingualTextValue::newFromArray( $monolingualValue );
+		}
+
+		return new static( $values );
+	}
+
+}

--- a/tests/phpunit/MonolingualTextValueTest.php
+++ b/tests/phpunit/MonolingualTextValueTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace DataValues\Tests;
+
+use DataValues\MonolingualTextValue;
+
+/**
+ * @covers DataValues\MonolingualTextValue
+ *
+ * @since 2.0
+ *
+ * @group DataValue
+ * @group DataValueExtensions
+ *
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class MonolingualTextValueTest extends DataValueTest {
+
+	/**
+	 * @see DataValueTest::getClass
+	 *
+	 * @return string
+	 */
+	public function getClass() {
+		return 'DataValues\MonolingualTextValue';
+	}
+
+	public function validConstructorArgumentsProvider() {
+		$argLists = array();
+
+		$argLists[] = array( 'en', 'foo' );
+		$argLists[] = array( 'en', ' foo bar baz foo bar baz foo bar baz foo bar baz foo bar baz foo bar baz ' );
+
+		return $argLists;
+	}
+
+	public function invalidConstructorArgumentsProvider() {
+		$argLists = array();
+
+		$argLists[] = array( 42, null );
+		$argLists[] = array( array(), null );
+		$argLists[] = array( false, null );
+		$argLists[] = array( true, null );
+		$argLists[] = array( null, null );
+		$argLists[] = array( 'en', 42 );
+		$argLists[] = array( 'en', false );
+		$argLists[] = array( 'en', array() );
+		$argLists[] = array( 'en', null );
+		$argLists[] = array( '', 'foo' );
+
+		return $argLists;
+	}
+
+	/**
+	 * @dataProvider instanceProvider
+	 * @param MonolingualTextValue $text
+	 * @param array $arguments
+	 */
+	public function testGetText( MonolingualTextValue $text, array $arguments ) {
+		$this->assertEquals( $arguments[1], $text->getText() );
+	}
+
+	/**
+	 * @dataProvider instanceProvider
+	 * @param MonolingualTextValue $text
+	 * @param array $arguments
+	 */
+	public function testGetLanguageCode( MonolingualTextValue $text, array $arguments ) {
+		$this->assertEquals( $arguments[0], $text->getLanguageCode() );
+	}
+
+}

--- a/tests/phpunit/MultilingualTextValueTest.php
+++ b/tests/phpunit/MultilingualTextValueTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace DataValues\Tests;
+
+use DataValues\MonolingualTextValue;
+use DataValues\MultilingualTextValue;
+
+/**
+ * @covers DataValues\MultilingualTextValue
+ *
+ * @since 2.0
+ *
+ * @group DataValue
+ * @group DataValueExtensions
+ *
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class MultilingualTextValueTest extends DataValueTest {
+
+	/**
+	 * @see DataValueTest::getClass
+	 *
+	 * @return string
+	 */
+	public function getClass() {
+		return 'DataValues\MultilingualTextValue';
+	}
+
+	public function validConstructorArgumentsProvider() {
+		$argLists = array();
+
+		$argLists[] = array( array() );
+		$argLists[] = array( array( new MonolingualTextValue( 'en', 'foo' ) ) );
+		$argLists[] = array( array( new MonolingualTextValue( 'en', 'foo' ), new MonolingualTextValue( 'de', 'foo' ) ) );
+		$argLists[] = array( array( new MonolingualTextValue( 'en', 'foo' ), new MonolingualTextValue( 'de', 'bar' ) ) );
+		$argLists[] = array( array(
+			new MonolingualTextValue( 'en', 'foo' ),
+			new MonolingualTextValue( 'de', ' foo bar baz foo bar baz foo bar baz foo bar baz foo bar baz foo bar baz ' )
+		) );
+
+		return $argLists;
+	}
+
+	public function invalidConstructorArgumentsProvider() {
+		$argLists = array();
+
+		$argLists[] = array( array( 42 ) );
+		$argLists[] = array( array( false ) );
+		$argLists[] = array( array( true ) );
+		$argLists[] = array( array( null ) );
+		$argLists[] = array( array( array() ) );
+		$argLists[] = array( array( 'foo' ) );
+
+		$argLists[] = array( array( 42 => 'foo' ) );
+		$argLists[] = array( array( '' => 'foo' ) );
+		$argLists[] = array( array( 'en' => 42 ) );
+		$argLists[] = array( array( 'en' => null ) );
+		$argLists[] = array( array( 'en' => true ) );
+		$argLists[] = array( array( 'en' => array() ) );
+		$argLists[] = array( array( 'en' => 4.2 ) );
+
+		$argLists[] = array( array( new MonolingualTextValue( 'en', 'foo' ), false ) );
+		$argLists[] = array( array( new MonolingualTextValue( 'en', 'foo' ), 'foobar' ) );
+
+		return $argLists;
+	}
+
+	/**
+	 * @dataProvider instanceProvider
+	 * @param MultilingualTextValue $texts
+	 * @param array $arguments
+	 */
+	public function testGetTexts( MultilingualTextValue $texts, array $arguments ) {
+		$actual = $texts->getTexts();
+
+		$this->assertInternalType( 'array', $actual );
+		$this->assertContainsOnlyInstancesOf( '\DataValues\MonolingualTextValue', $actual );
+		$this->assertEquals( $arguments[0], array_values( $actual ) );
+	}
+
+	/**
+	 * @dataProvider instanceProvider
+	 * @param MultilingualTextValue $texts
+	 * @param array $arguments
+	 */
+	public function testGetValue( MultilingualTextValue $texts, array $arguments ) {
+		$this->assertInstanceOf( $this->getClass(), $texts->getValue() );
+	}
+
+}


### PR DESCRIPTION
I always found the borders and responsibilities of the three components
- `data-values/common`
- `data-values/data-values`
- `data-values/interfaces`

a bit confusing. DataValues contains interfaces in addition to Interfaces. Commons contains DataValue classes in addition to DataValues.

With these two patches (the other one being https://github.com/DataValues/Common/pull/29):
- Common will not contain any DataValue classes any more, only other common stuff (formatters and parsers).
- DataValues will contain **all** common DataValue classes.
