### PR TITLE
Update PHP CodeSniffer rule set to 0.9.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ php:
   - 7
   - hhvm
 
-before_script:
+install:
   - travis_retry composer install
 
 script:

--- a/DataValues.mw.php
+++ b/DataValues.mw.php
@@ -34,10 +34,6 @@ $GLOBALS['wgExtensionMessagesFiles']['DataValues'] = __DIR__ . '/DataValues.i18n
  *
  * @return boolean
  */
-$GLOBALS['wgHooks']['ExtensionTypes'][] = function( array &$extensionTypes ) {
-	// @codeCoverageIgnoreStart
+$GLOBALS['wgHooks']['ExtensionTypes'][] = function ( array &$extensionTypes ) {
 	$extensionTypes['datavalues'] = wfMessage( 'version-datavalues' )->text();
-
-	return true;
-	// @codeCoverageIgnoreEnd
 };

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
 		"php": ">=5.5.9"
 	},
 	"require-dev": {
-		"mediawiki/mediawiki-codesniffer": "0.7.2",
+		"mediawiki/mediawiki-codesniffer": "0.9.0",
 		"phpunit/phpunit": "~4.8"
 	},
 	"replace": {
@@ -51,7 +51,7 @@
 			"phpunit"
 		],
 		"phpcs": [
-			"phpcs src/* tests/* --standard=phpcs.xml -sp"
+			"phpcs -p -s"
 		]
 	}
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -3,6 +3,7 @@
 	<!-- See https://github.com/wikimedia/mediawiki-tools-codesniffer/blob/master/MediaWiki/ruleset.xml -->
 	<rule ref="vendor/mediawiki/mediawiki-codesniffer/MediaWiki">
 		<exclude name="Generic.Arrays.DisallowLongArraySyntax" />
+		<exclude name="MediaWiki.Commenting.FunctionComment" />
 		<exclude name="PSR2.Methods.MethodDeclaration.AbstractAfterVisibility" />
 	</rule>
 
@@ -12,6 +13,9 @@
 	<rule ref="PSR1">
 		<exclude name="PSR1.Classes.ClassDeclaration.MissingNamespace" />
 	</rule>
+	<rule ref="PSR1.Files.SideEffects.FoundWithSymbols">
+		<exclude-pattern>DataValues\.php</exclude-pattern>
+	</rule>
 	<rule ref="PSR1.Methods.CamelCapsMethodName.NotCamelCaps">
 		<!-- Exclude test methods like "testGivenInvalidInput_methodThrowsException". -->
 		<exclude-pattern>tests*Test*\.php</exclude-pattern>
@@ -19,7 +23,6 @@
 
 	<rule ref="PSR2.Files" />
 
-	<rule ref="Squiz.Classes.DuplicateProperty" />
 	<rule ref="Squiz.Classes.SelfMemberReference" />
 	<rule ref="Squiz.ControlStructures.ControlSignature" />
 	<rule ref="Squiz.Functions.FunctionDuplicateArgument" />
@@ -38,4 +41,7 @@
 
 	<arg name="extensions" value="php" />
 	<arg name="encoding" value="utf8" />
+	<file>.</file>
+	<exclude-pattern type="relative">^vendor/</exclude-pattern>
+	<exclude-pattern>DataValues\.i18n\.php</exclude-pattern>
 </ruleset>

--- a/tests/phpunit/DataValueTest.php
+++ b/tests/phpunit/DataValueTest.php
@@ -57,7 +57,7 @@ abstract class DataValueTest extends PHPUnit_Framework_TestCase {
 		$instanceBuilder = [ $this, 'newInstance' ];
 
 		return array_map(
-			function( array $args ) use ( $instanceBuilder ) {
+			function ( array $args ) use ( $instanceBuilder ) {
 				return [
 					call_user_func_array( $instanceBuilder, $args ),
 					$args


### PR DESCRIPTION
The "DuplicateProperty" sniff is a pure JavaScript sniff, not relevant in this code repository.