### PR TITLE
Fix inline @see tags

### DIFF
--- a/src/DataValues/BooleanValue.php
+++ b/src/DataValues/BooleanValue.php
@@ -74,19 +74,19 @@ class BooleanValue extends DataValueObject {
 	}
 
 	/**
-	 * Constructs a new instance from the provided data. Required for @see DataValueDeserializer.
-	 * This is expected to round-trip with @see getArrayValue.
+	 * Constructs a new instance from the provided data. Required for {@see DataValueDeserializer}.
+	 * This is expected to round-trip with {@see getArrayValue}.
 	 *
 	 * @deprecated since 1.1. Static DataValue::newFromArray constructors like this are
 	 *  underspecified (not in the DataValue interface), and misleadingly named (should be named
-	 *  newFromArrayValue). Instead, use DataValue builder callbacks in @see DataValueDeserializer.
+	 *  newFromArrayValue). Instead, use DataValue builder callbacks in {@see DataValueDeserializer}.
 	 *
 	 * @param mixed $data Warning! Even if this is expected to be a value as returned by
-	 *  @see getArrayValue, callers of this specific newFromArray implementation can not guarantee
+	 *  {@see getArrayValue}, callers of this specific newFromArray implementation can not guarantee
 	 *  this. This is not guaranteed to be a boolean!
 	 *
 	 * @throws IllegalValueException if $data is not in the expected format. Subclasses of
-	 *  InvalidArgumentException are expected and properly handled by @see DataValueDeserializer.
+	 *  InvalidArgumentException are expected and properly handled by {@see DataValueDeserializer}.
 	 * @return self
 	 */
 	public static function newFromArray( $data ) {

--- a/src/DataValues/DataValue.php
+++ b/src/DataValues/DataValue.php
@@ -57,7 +57,7 @@ interface DataValue extends Hashable, Comparable, Serializable, Immutable {
 	/**
 	 * Returns the value in a form suitable for an array serialization.
 	 *
-	 * For simple values (ie a string) the return value will be equal to that of @see getValue.
+	 * For simple values (ie a string) the return value will be equal to that of {@see getValue}.
 	 *
 	 * Complex DataValues can provide a nicer implementation though, for instance a
 	 * geographical coordinate value could provide an array with keys latitude,
@@ -73,8 +73,8 @@ interface DataValue extends Hashable, Comparable, Serializable, Immutable {
 	 * Returns the whole DataValue in array form.
 	 *
 	 * The array contains:
-	 * - value: mixed, same as the result of @see getArrayValue
-	 * - type: string, same as the result of @see getType
+	 * - value: mixed, same as the result of {@see getArrayValue}
+	 * - type: string, same as the result of {@see getType}
 	 *
 	 * This is sufficient for unserialization in a factory.
 	 *

--- a/src/DataValues/NumberValue.php
+++ b/src/DataValues/NumberValue.php
@@ -6,7 +6,7 @@ namespace DataValues;
  * Class representing a simple numeric value.
  *
  * More complex numeric values that have associated info such as
- * unit and accuracy can be represented with a @see QuantityValue.
+ * unit and accuracy can be represented with a {@see QuantityValue}.
  *
  * @since 0.1
  *
@@ -80,19 +80,19 @@ class NumberValue extends DataValueObject {
 	}
 
 	/**
-	 * Constructs a new instance from the provided data. Required for @see DataValueDeserializer.
-	 * This is expected to round-trip with @see getArrayValue.
+	 * Constructs a new instance from the provided data. Required for {@see DataValueDeserializer}.
+	 * This is expected to round-trip with {@see getArrayValue}.
 	 *
 	 * @deprecated since 1.1. Static DataValue::newFromArray constructors like this are
 	 *  underspecified (not in the DataValue interface), and misleadingly named (should be named
-	 *  newFromArrayValue). Instead, use DataValue builder callbacks in @see DataValueDeserializer.
+	 *  newFromArrayValue). Instead, use DataValue builder callbacks in {@see DataValueDeserializer}.
 	 *
 	 * @param mixed $data Warning! Even if this is expected to be a value as returned by
-	 *  @see getArrayValue, callers of this specific newFromArray implementation can not guarantee
+	 *  {@see getArrayValue}, callers of this specific newFromArray implementation can not guarantee
 	 *  this. This is not guaranteed to be a number!
 	 *
 	 * @throws IllegalValueException if $data is not in the expected format. Subclasses of
-	 *  InvalidArgumentException are expected and properly handled by @see DataValueDeserializer.
+	 *  InvalidArgumentException are expected and properly handled by {@see DataValueDeserializer}.
 	 * @return self
 	 */
 	public static function newFromArray( $data ) {

--- a/src/DataValues/StringValue.php
+++ b/src/DataValues/StringValue.php
@@ -77,19 +77,19 @@ class StringValue extends DataValueObject {
 	}
 
 	/**
-	 * Constructs a new instance from the provided data. Required for @see DataValueDeserializer.
-	 * This is expected to round-trip with @see getArrayValue.
+	 * Constructs a new instance from the provided data. Required for {@see DataValueDeserializer}.
+	 * This is expected to round-trip with {@see getArrayValue}.
 	 *
 	 * @deprecated since 1.1. Static DataValue::newFromArray constructors like this are
 	 *  underspecified (not in the DataValue interface), and misleadingly named (should be named
-	 *  newFromArrayValue). Instead, use DataValue builder callbacks in @see DataValueDeserializer.
+	 *  newFromArrayValue). Instead, use DataValue builder callbacks in {@see DataValueDeserializer}.
 	 *
 	 * @param mixed $data Warning! Even if this is expected to be a value as returned by
-	 *  @see getArrayValue, callers of this specific newFromArray implementation can not guarantee
+	 *  {@see getArrayValue}, callers of this specific newFromArray implementation can not guarantee
 	 *  this. This is not guaranteed to be a string!
 	 *
 	 * @throws IllegalValueException if $data is not in the expected format. Subclasses of
-	 *  InvalidArgumentException are expected and properly handled by @see DataValueDeserializer.
+	 *  InvalidArgumentException are expected and properly handled by {@see DataValueDeserializer}.
 	 * @return self
 	 */
 	public static function newFromArray( $data ) {

--- a/src/DataValues/UnknownValue.php
+++ b/src/DataValues/UnknownValue.php
@@ -88,12 +88,12 @@ class UnknownValue extends DataValueObject {
 	}
 
 	/**
-	 * Constructs a new instance from the provided data. Required for @see DataValueDeserializer.
-	 * This is expected to round-trip with @see getArrayValue.
+	 * Constructs a new instance from the provided data. Required for {@see DataValueDeserializer}.
+	 * This is expected to round-trip with {@see getArrayValue}.
 	 *
 	 * @deprecated since 1.1. Static DataValue::newFromArray constructors like this are
 	 *  underspecified (not in the DataValue interface), and misleadingly named (should be named
-	 *  newFromArrayValue). Instead, use DataValue builder callbacks in @see DataValueDeserializer.
+	 *  newFromArrayValue). Instead, use DataValue builder callbacks in {@see DataValueDeserializer}.
 	 *
 	 * @param mixed $data
 	 *


### PR DESCRIPTION
`@see` not wrapped inside braces is interpreted by IntelliJ as a block tag that ends the text block, resulting in cut-off documentation like this:

> Returns the value in a form suitable for an array serialization.
> For simple values (ie a string) the return value will be equal to that of

Occurrences found with the following command:
```sh
git grep '[^*] @see'
```