### PR TITLE
Remove DataValue::getSortKey and getCopy

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ Contributions where also made by
 
 ### 3.0.0 (dev)
 
+* Removed `getCopy` from the `DataValue` interface and all implementations
+* Removed `getSortKey` from the `DataValue` interface and all implementations
 * Removed `DATAVALUES_VERSION` constant
 * Removed `DataValueTest` (create a copy if you need it, though better refactor away the bad design)
 * Raised minimum PHP version from 5.5.9 to 7.2

--- a/src/DataValues/BooleanValue.php
+++ b/src/DataValues/BooleanValue.php
@@ -47,15 +47,6 @@ class BooleanValue extends DataValueObject {
 	}
 
 	/**
-	 * @see DataValue::getSortKey
-	 *
-	 * @return int 0 for false, 1 for true.
-	 */
-	public function getSortKey() {
-		return $this->value ? 1 : 0;
-	}
-
-	/**
 	 * Returns the boolean.
 	 * @see DataValue::getValue
 	 *

--- a/src/DataValues/DataValue.php
+++ b/src/DataValues/DataValue.php
@@ -24,16 +24,6 @@ interface DataValue extends Hashable, Comparable, Serializable, Immutable {
 	public static function getType();
 
 	/**
-	 * Returns a key that can be used to sort the data value with.
-	 * It can be either numeric or a string.
-	 *
-	 * @since 0.1
-	 *
-	 * @return string|float|int
-	 */
-	public function getSortKey();
-
-	/**
 	 * Returns the value contained by the DataValue. If this value is not simple and
 	 * does not have it's own type that represents it, the DataValue itself will be returned.
 	 * In essence, this method returns the "simplest" representation of the value.
@@ -78,14 +68,5 @@ interface DataValue extends Hashable, Comparable, Serializable, Immutable {
 	 * @return array
 	 */
 	public function toArray();
-
-	/**
-	 * Returns a deep copy of the object.
-	 *
-	 * @since 0.1
-	 *
-	 * @return DataValue
-	 */
-	public function getCopy();
 
 }

--- a/src/DataValues/DataValueObject.php
+++ b/src/DataValues/DataValueObject.php
@@ -34,15 +34,6 @@ abstract class DataValueObject implements DataValue {
 	}
 
 	/**
-	 * @see DataValue::getCopy
-	 *
-	 * @return DataValue
-	 */
-	public function getCopy() {
-		return unserialize( serialize( $this ) );
-	}
-
-	/**
 	 * @see DataValue::getArrayValue
 	 *
 	 * @return mixed

--- a/src/DataValues/NumberValue.php
+++ b/src/DataValues/NumberValue.php
@@ -56,15 +56,6 @@ class NumberValue extends DataValueObject {
 	}
 
 	/**
-	 * @see DataValue::getSortKey
-	 *
-	 * @return int|float
-	 */
-	public function getSortKey() {
-		return $this->value;
-	}
-
-	/**
 	 * Returns the number.
 	 * @see DataValue::getValue
 	 *

--- a/src/DataValues/StringValue.php
+++ b/src/DataValues/StringValue.php
@@ -50,15 +50,6 @@ class StringValue extends DataValueObject {
 	}
 
 	/**
-	 * @see DataValue::getSortKey
-	 *
-	 * @return string
-	 */
-	public function getSortKey() {
-		return $this->value;
-	}
-
-	/**
 	 * Returns the string.
 	 * @see DataValue::getValue
 	 *

--- a/src/DataValues/UnDeserializableValue.php
+++ b/src/DataValues/UnDeserializableValue.php
@@ -132,15 +132,6 @@ class UnDeserializableValue extends DataValueObject {
 	}
 
 	/**
-	 * @see DataValue::getSortKey
-	 *
-	 * @return int Always 0 in this implementation.
-	 */
-	public function getSortKey() {
-		return 0;
-	}
-
-	/**
 	 * Returns the raw data structure.
 	 * @see DataValue::getValue
 	 *

--- a/src/DataValues/UnknownValue.php
+++ b/src/DataValues/UnknownValue.php
@@ -48,15 +48,6 @@ class UnknownValue extends DataValueObject {
 	}
 
 	/**
-	 * @see DataValue::getSortKey
-	 *
-	 * @return int Always 0 in this implementation.
-	 */
-	public function getSortKey() {
-		return 0;
-	}
-
-	/**
 	 * Returns the value.
 	 * @see DataValue::getValue
 	 *

--- a/tests/phpunit/DataValueTest.php
+++ b/tests/phpunit/DataValueTest.php
@@ -136,17 +136,6 @@ abstract class DataValueTest extends TestCase {
 
 		$this->assertIsString( $hash );
 		$this->assertEquals( $hash, $value->getHash() );
-		$this->assertEquals( $hash, $value->getCopy()->getHash() );
-	}
-
-	/**
-	 * @dataProvider instanceProvider
-	 */
-	public function testGetCopy( DataValue $value, array $arguments ) {
-		$copy = $value->getCopy();
-
-		$this->assertInstanceOf( DataValue::class, $copy );
-		$this->assertTrue( $value->equals( $copy ) );
 	}
 
 	/**


### PR DESCRIPTION
@JeroenDeDauw, can you please have a look if this is ok? I checked the SemanticMediaWiki code. It looks like it is not using this library (any more), but it's own SMWDataValue instead. Can you confirm this?