### PR TITLE
Include test folder again in release

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,4 +5,3 @@
 composer.json export-ignore
 phpcs.xml export-ignore
 phpunit.xml.dist export-ignore
-tests export-ignore


### PR DESCRIPTION
This package specifies a test class to be autoloaded https://github.com/DataValues/DataValues/blob/master/composer.json#L36

When test folder is omitted from a release, another package using this package will fail to update as composer will fail in generate autoload dumps when trying to locate that test class.

Encountered in https://phabricator.wikimedia.org/T232063