### PR TITLE
Update requirements in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@ On [Packagist](https://packagist.org/packages/data-values/data-values):
 
 These PHP versions are supported:
 
-* PHP 5.5 or later, including PHP 7
-* HHVM 3.3 or later
+* PHP 7.2 or later
 
 ## Installation
 


### PR DESCRIPTION
The required PHP version was bumped in 71a308fa13, and we stopped testing HHVM in a76ffa85cc.