### PR TITLE
Make DataValue hashes robust for PHP 7.4+

### DIFF
--- a/src/BooleanValue.php
+++ b/src/BooleanValue.php
@@ -30,6 +30,10 @@ class BooleanValue extends DataValueObject {
 		return $this->value ? '1' : '0';
 	}
 
+	public function __serialize(): array {
+		return [ $this->serialize() ];
+	}
+
 	/**
 	 * @see Serializable::unserialize
 	 *
@@ -37,6 +41,10 @@ class BooleanValue extends DataValueObject {
 	 */
 	public function unserialize( $value ) {
 		$this->value = $value === '1';
+	}
+
+	public function __unserialize( array $data ): void {
+		$this->unserialize( $data[ 0 ] );
 	}
 
 	/**

--- a/src/DataValueObject.php
+++ b/src/DataValueObject.php
@@ -13,7 +13,20 @@ abstract class DataValueObject implements DataValue {
 	 * @return string
 	 */
 	public function getHash() {
-		return md5( serialize( $this ) );
+		return md5( $this->getSerializationForHash() );
+	}
+
+	/**
+	 * Get legacy PHP serialization (as PHP up to version 7.3 would produce).
+	 * This is used for self::getHash to make sure hashes stay consistent.
+	 * It must not be used to produce serialization meant to be deserialized.
+	 *
+	 * @return string
+	 */
+	public function getSerializationForHash(): string {
+		$data = $this->serialize();
+		return 'C:' . strlen( static::class ) . ':"' . static::class .
+			'":' . strlen( $data ) . ':{' . $data . '}';
 	}
 
 	/**

--- a/src/NumberValue.php
+++ b/src/NumberValue.php
@@ -39,6 +39,10 @@ class NumberValue extends DataValueObject {
 		return serialize( $this->value );
 	}
 
+	public function __serialize(): array {
+		return [ $this->value ];
+	}
+
 	/**
 	 * @see Serializable::unserialize
 	 *
@@ -46,6 +50,10 @@ class NumberValue extends DataValueObject {
 	 */
 	public function unserialize( $value ) {
 		$this->__construct( unserialize( $value ) );
+	}
+
+	public function __unserialize( array $data ): void {
+		$this->__construct( $data[0] );
 	}
 
 	/**

--- a/src/StringValue.php
+++ b/src/StringValue.php
@@ -33,6 +33,10 @@ class StringValue extends DataValueObject {
 		return $this->value;
 	}
 
+	public function __serialize(): array {
+		return [ $this->serialize() ];
+	}
+
 	/**
 	 * @see Serializable::unserialize
 	 *
@@ -40,6 +44,10 @@ class StringValue extends DataValueObject {
 	 */
 	public function unserialize( $value ) {
 		$this->__construct( $value );
+	}
+
+	public function __unserialize( array $data ): void {
+		$this->unserialize( $data[0] );
 	}
 
 	/**

--- a/src/UnDeserializableValue.php
+++ b/src/UnDeserializableValue.php
@@ -67,6 +67,10 @@ class UnDeserializableValue extends DataValueObject {
 		return serialize( [ $this->type, $this->data, $this->error ] );
 	}
 
+	public function __serialize(): array {
+		return [ $this->data, $this->type, $this->error ];
+	}
+
 	/**
 	 * @see Serializable::unserialize
 	 *
@@ -75,6 +79,10 @@ class UnDeserializableValue extends DataValueObject {
 	public function unserialize( $value ) {
 		list( $type, $data, $error ) = unserialize( $value );
 		$this->__construct( $data, $type, $error );
+	}
+
+	public function __unserialize( array $data ): void {
+		$this->__construct( ...$data );
 	}
 
 	/**

--- a/src/UnknownValue.php
+++ b/src/UnknownValue.php
@@ -31,6 +31,10 @@ class UnknownValue extends DataValueObject {
 		return serialize( $this->value );
 	}
 
+	public function __serialize(): array {
+		return [ $this->value ];
+	}
+
 	/**
 	 * @see Serializable::unserialize
 	 *
@@ -38,6 +42,10 @@ class UnknownValue extends DataValueObject {
 	 */
 	public function unserialize( $value ) {
 		$this->__construct( unserialize( $value ) );
+	}
+
+	public function __unserialize( array $data ): void {
+		$this->__construct( $data[0] );
 	}
 
 	/**

--- a/tests/phpunit/BooleanValueTest.php
+++ b/tests/phpunit/BooleanValueTest.php
@@ -52,4 +52,21 @@ class BooleanValueTest extends DataValueTest {
 		$this->assertEquals( $arguments[0], $boolean->getValue() );
 	}
 
+	/** @dataProvider instanceWithHashProvider */
+	public function testGetHashStability( BooleanValue $string, string $hash ) {
+		$this->assertSame( $hash, $string->getHash() );
+	}
+
+	public function instanceWithHashProvider(): iterable {
+		// all hashes obtained from data-values/data-values==3.0.0 under PHP 7.2.34
+		yield 'true' => [
+			new BooleanValue( true ),
+			'8e4870384e54b7ba67b8da5ee127b274',
+		];
+		yield 'false' => [
+			new BooleanValue( false ),
+			'a3129f65af06a7c987ef5077ad3e9950',
+		];
+	}
+
 }

--- a/tests/phpunit/BooleanValueTest.php
+++ b/tests/phpunit/BooleanValueTest.php
@@ -52,16 +52,4 @@ class BooleanValueTest extends DataValueTest {
 		$this->assertEquals( $arguments[0], $boolean->getValue() );
 	}
 
-	public function testSerializationStability(): void {
-		$this->assertSame(
-			'C:23:"DataValues\BooleanValue":1:{1}', // Obtained with PHP 8.1.5, tested down to PHP 7.2
-			serialize( new BooleanValue( true ) )
-		);
-
-		$this->assertSame(
-			'C:23:"DataValues\BooleanValue":1:{0}', // Obtained with PHP 8.1.5, tested down to PHP 7.2
-			serialize( new BooleanValue( false ) )
-		);
-	}
-
 }

--- a/tests/phpunit/DataValueTest.php
+++ b/tests/phpunit/DataValueTest.php
@@ -137,6 +137,20 @@ abstract class DataValueTest extends TestCase {
 	/**
 	 * @dataProvider instanceProvider
 	 */
+	public function testGetSerializationForHash( DataValue $value, array $arguments ) {
+		$serialization = $value->getSerializationForHash();
+
+		$this->assertTrue( $value->equals( unserialize( $serialization ) ) );
+		if ( version_compare( phpversion(), '7.4', '<' ) || !method_exists( $value, '__serialize' ) ) {
+			// If we run PHP 7.3 (or older), or $value doesn't yet have the __serialize method,
+			// the default PHP serialization should match our legacy format.
+			$this->assertSame( serialize( $value ), $serialization );
+		}
+	}
+
+	/**
+	 * @dataProvider instanceProvider
+	 */
 	public function testGetValueSimple( DataValue $value, array $arguments ) {
 		$value->getValue();
 		$this->assertTrue( true );

--- a/tests/phpunit/NumberValueTest.php
+++ b/tests/phpunit/NumberValueTest.php
@@ -58,16 +58,4 @@ class NumberValueTest extends DataValueTest {
 		$this->assertEquals( $arguments[0], $number->getValue() );
 	}
 
-	public function testSerializationStability(): void {
-		$this->assertSame(
-			'C:22:"DataValues\NumberValue":5:{i:42;}', // Obtained with PHP 8.1.5, tested down to PHP 7.2
-			serialize( new NumberValue( 42 ) )
-		);
-
-		$this->assertSame(
-			'C:22:"DataValues\NumberValue":7:{d:-4.2;}', // Obtained with PHP 8.1.5, tested down to PHP 7.2
-			serialize( new NumberValue( -4.2 ) )
-		);
-	}
-
 }

--- a/tests/phpunit/NumberValueTest.php
+++ b/tests/phpunit/NumberValueTest.php
@@ -58,4 +58,29 @@ class NumberValueTest extends DataValueTest {
 		$this->assertEquals( $arguments[0], $number->getValue() );
 	}
 
+	/** @dataProvider instanceWithHashProvider */
+	public function testGetHashStability( NumberValue $string, string $hash ) {
+		$this->assertSame( $hash, $string->getHash() );
+	}
+
+	public function instanceWithHashProvider(): iterable {
+		// all hashes obtained from data-values/data-values==3.0.0 under PHP 7.2.34
+		yield 'int 0' => [
+			new NumberValue( 0 ),
+			'81277795dbf8a1fd3d0251763ec31542',
+		];
+		yield 'int 1337' => [
+			new NumberValue( 1337 ),
+			'a458da273f208b6c0345061c84dc4edd',
+		];
+		yield 'float 0.0' => [
+			new NumberValue( 0.0 ),
+			'c750d1ddbacf64a45afaa2e71b24c381'
+		];
+		yield 'float 13.37' => [
+			new NumberValue( 13.37 ),
+			'f3f2807ccf5697277cf37176e3b9eb3d',
+		];
+	}
+
 }

--- a/tests/phpunit/StringValueTest.php
+++ b/tests/phpunit/StringValueTest.php
@@ -50,16 +50,4 @@ class StringValueTest extends DataValueTest {
 		$this->assertEquals( $arguments[0], $string->getValue() );
 	}
 
-	public function testSerializationStability(): void {
-		$this->assertSame(
-			'C:22:"DataValues\StringValue":0:{}', // Obtained with PHP 8.1.5, tested down to PHP 7.2
-			serialize( new StringValue( '' ) )
-		);
-
-		$this->assertSame(
-			'C:22:"DataValues\StringValue":7:{pew pew}', // Obtained with PHP 8.1.5, tested down to PHP 7.2
-			serialize( new StringValue( 'pew pew' ) )
-		);
-	}
-
 }

--- a/tests/phpunit/StringValueTest.php
+++ b/tests/phpunit/StringValueTest.php
@@ -50,4 +50,21 @@ class StringValueTest extends DataValueTest {
 		$this->assertEquals( $arguments[0], $string->getValue() );
 	}
 
+	/** @dataProvider instanceWithHashProvider */
+	public function testGetHashStability( StringValue $string, string $hash ) {
+		$this->assertSame( $hash, $string->getHash() );
+	}
+
+	public function instanceWithHashProvider(): iterable {
+		// all hashes obtained from data-values/data-values==3.0.0 under PHP 7.2.34
+		yield 'empty' => [
+			new StringValue( '' ),
+			'322af78b3f40f91da92c3d8dd9c015f2',
+		];
+		yield 'abc' => [
+			new StringValue( 'abc' ),
+			'9d118479352d30db2f37ec6a0e664821',
+		];
+	}
+
 }

--- a/tests/phpunit/UnDeserializableValueTest.php
+++ b/tests/phpunit/UnDeserializableValueTest.php
@@ -87,12 +87,4 @@ class UnDeserializableValueTest extends DataValueTest {
 		$this->assertFalse( method_exists( $this->getClass(), 'newFromArray' ) );
 	}
 
-	public function testSerializationStability(): void {
-		$this->assertSame(
-			// Obtained with PHP 8.1.5, tested down to PHP 7.2
-			'C:32:"DataValues\UnDeserializableValue":49:{a:3:{i:0;N;i:1;N;i:2;s:19:"No type and no data";}}',
-			serialize( new UnDeserializableValue( null, null, 'No type and no data' ) )
-		);
-	}
-
 }

--- a/tests/phpunit/UnknownValueTest.php
+++ b/tests/phpunit/UnknownValueTest.php
@@ -54,11 +54,4 @@ class UnknownValueTest extends DataValueTest {
 		$this->assertEquals( $arguments[0], $value->getValue() );
 	}
 
-	public function testSerializationStability(): void {
-		$this->assertSame(
-			'C:23:"DataValues\UnknownValue":6:{a:0:{}}', // Obtained with PHP 8.1.5, tested down to PHP 7.2
-			serialize( new UnknownValue( [] ) )
-		);
-	}
-
 }


### PR DESCRIPTION
These hashes are based upon the PHP serialization, which will change if `__serialize` and `__unserialize` are implemented and PHP >= 7.4 is used.